### PR TITLE
Add `call`, `attachment`, and `inline` convenience methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ ContentDisposition.format(
 # => "attachment; filename=\"racecar.jpg\"; filename*=UTF-8''r%C3%A5c%C3%AB%C3%A7%C3%A2r.jpg"
 ```
 
+There are `.attachment` and `.inline` shorthands for doing the same:
+
+```rb
+ContentDisposition.attachment("racecar.jpg")
+# => "attachment; filename=\"racecar.jpg\"; filename*=UTF-8''racecar.jpg"
+ContentDisposition.inline("racecar.jpg")
+# => "inline; filename=\"racecar.jpg\"; filename*=UTF-8''racecar.jpg"
+```
+
 That's it.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ ContentDisposition.format(
 # => "attachment; filename=\"racecar.jpg\"; filename*=UTF-8''r%C3%A5c%C3%AB%C3%A7%C3%A2r.jpg"
 ```
 
-There are `.attachment` and `.inline` shorthands for doing the same:
+The `.format` method is aliased to `.call`, so you can do:
+
+```rb
+ContentDisposition.(disposition: "attachment", filename: "råcëçâr.jpg")
+```
+
+There are also `.attachment` and `.inline` shorthands:
 
 ```rb
 ContentDisposition.attachment("racecar.jpg")

--- a/lib/content_disposition.rb
+++ b/lib/content_disposition.rb
@@ -9,6 +9,10 @@ class ContentDisposition
     new(disposition: disposition, filename: filename, to_ascii: to_ascii).to_s
   end
 
+  def self.call(*args)
+    format(*args)
+  end
+
   def self.attachment(filename = nil)
     format(disposition: "attachment", filename: filename)
   end

--- a/lib/content_disposition.rb
+++ b/lib/content_disposition.rb
@@ -9,6 +9,14 @@ class ContentDisposition
     new(disposition: disposition, filename: filename, to_ascii: to_ascii).to_s
   end
 
+  def self.attachment(filename = nil)
+    format(disposition: "attachment", filename: filename)
+  end
+
+  def self.inline(filename = nil)
+    format(disposition: "inline", filename: filename)
+  end
+
   attr_reader :disposition, :filename, :to_ascii
 
   def initialize(disposition:, filename:, to_ascii: DEFAULT_TO_ASCII)

--- a/spec/content_disposition_spec.rb
+++ b/spec/content_disposition_spec.rb
@@ -65,5 +65,31 @@ RSpec.describe ContentDisposition do
     end
   end
 
+  describe ".attachment" do
+    it "accepts a filename" do
+      value = ContentDisposition.attachment("racecar.jpg")
 
+      expect(value).to eq %(attachment; filename="racecar.jpg"; filename*=UTF-8''racecar.jpg)
+    end
+
+    it "works without a filename" do
+      value = ContentDisposition.attachment
+
+      expect(value).to eq %(attachment)
+    end
+  end
+
+  describe ".inline" do
+    it "accepts a filename" do
+      value = ContentDisposition.inline("racecar.jpg")
+
+      expect(value).to eq %(inline; filename="racecar.jpg"; filename*=UTF-8''racecar.jpg)
+    end
+
+    it "works without a filename" do
+      value = ContentDisposition.inline
+
+      expect(value).to eq %(inline)
+    end
+  end
 end

--- a/spec/content_disposition_spec.rb
+++ b/spec/content_disposition_spec.rb
@@ -65,6 +65,14 @@ RSpec.describe ContentDisposition do
     end
   end
 
+  describe ".call" do
+    it "aliases .format" do
+      value = ContentDisposition.(disposition: "attachment", filename: "racecar.jpg")
+
+      expect(value).to eq %(attachment; filename="racecar.jpg"; filename*=UTF-8''racecar.jpg)
+    end
+  end
+
   describe ".attachment" do
     it "accepts a filename" do
       value = ContentDisposition.attachment("racecar.jpg")


### PR DESCRIPTION
I think it's nice to have additional convenience methods for doing the same, and these are the ones I wished for.

I find it easier to organize specs by methods, so that's what I did here.