### PR TITLE
Replace travis with Github Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ '**' ]
+
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 2.4
+          - 2.5
+          - ruby-head
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+
+
+    - name: Run tests
+      run: bundle exec rspec
+
+
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [ '**' ]
 
-
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -19,7 +18,6 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - ruby-head
 
     steps:
     - uses: actions/checkout@v2
@@ -30,10 +28,5 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
 
-
     - name: Run tests
       run: bundle exec rspec
-
-
-
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
+          - jruby-9.2
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
         ruby:
           - 2.4
           - 2.5
+          - 2.6
+          - 2.7
           - ruby-head
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - 2.3
           - 2.4
           - 2.5
           - 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
----
-language: ruby
-rvm:
-  - 2.4.5
-  - 2.5.3
-  - ruby-head
-
-before_install: gem install bundler -v 1.17.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "byebug"


### PR DESCRIPTION
Github Actions doesn't have a simple "allow_failures" option. We are for now including `ruby-head` in as an ordinary required-pass (it currently passes). 

That's how it was in the .travis.yml too, although the .travis.yml may have never been actually used. 